### PR TITLE
Add the option to allow custom properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,87 +1,129 @@
+/* jshint unused:strict */
 'use strict';
 
 var Backbone = require('backbone');
 var _        = require('underscore');
 
-var protectedMethods = [
-  'listenTo',
-  'on',
-  'trigger',
-  'clone',
-  'destroy',
-  'initialize',
-  'stopListening',
-  'length',
-  'model',
-  'models'
-];
+var BackboneCollectionPrototype = Backbone.Collection.prototype;
+var Events = Backbone.Events;
 
-function ProxyCollection(attrs, options) {
-  attrs = (attrs || {});
-  attrs.collection = (attrs.collection || new Backbone.Collection());
-  this.collection = attrs.collection;
+function ProxyCollection(attrs) {
+  this.collection = attrs && attrs.collection || new Backbone.Collection();
   this._bindToCollection();
-  this._syncWithCollection();
+
+  Object.defineProperty(this, 'length', {
+    get: function() {
+      return this.collection.length;
+    }
+  });
+
+  Object.defineProperty(this, 'models', {
+    get: function() {
+      return this.collection.models;
+    }
+  });
+
+  Object.defineProperty(this, 'model', {
+    get: function() {
+      return this.collection.model;
+    }
+  });
+
+  Object.defineProperty(this, 'comparator', {
+    get: function() {
+      return this.collection.comparator;
+    },
+    set: function(value) {
+      return (this.collection.comparator = value);
+    }
+  });
+
+  // Define additional properties
+  var additionalProperties = attrs.properties;
+  if (additionalProperties) {
+    additionalProperties.forEach(function(property) {
+      Object.defineProperty(this, property, {
+        get: function() {
+          return this.collection[property];
+        },
+        set: function(value) {
+          return (this.collection[property] = value);
+        }
+      });
+    }, this);
+  }
+
+  // Add any additional methods for this klass
+  var klass = attrs && attrs.klass;
+  if (klass && klass.prototype) {
+    Object.keys(klass.prototype).forEach(function(key) {
+      var entry = klass.prototype[key];
+
+      if (allowMethod(key, entry)) {
+        this[key] = function() {
+          return this.collection[key].apply(this.collection, arguments);
+        };
+      }
+    }, this);
+  }
 }
 
-ProxyCollection.prototype = _.extend({}, Backbone.Events, {
+ProxyCollection.prototype = _.extend({
 
-  initialize: function() {},
+    clone: function() {
+      //TODO: what about other attributes passed to ProxyCollection?
+      return new ProxyCollection({
+        collection: this.collection.clone(),
+      });
+    },
 
-  clone: function() {
-    //TODO: what about other attributes passed to ProxyCollection?
-    return new ProxyCollection({
-      collection: this.collection.clone(),
-    });
-  },
+    destroy: function() {
+      this._unbind();
+    },
 
-  destroy: function() {
-    this._unbind();
-  },
+    switchCollection: function (collection) {
+      if (!collection) {
+        throw new Error('A valid collection must be passed to ProxyCollection.switchCollection');
+      }
 
-  switchCollection: function (collection){
-    if (!collection) {
-      throw new Error('A valid collection must be passed to ProxyCollection.switchCollection');
+      if (this.collection === collection) return;
+
+      this._unbind();
+      this.collection = collection;
+      this._bindToCollection();
+      this.trigger('reset', this, { switched: true });
+    },
+
+    _onCollectionEvent: function() {
+      this.trigger.apply(this, arguments);
+    },
+
+    _bindToCollection: function() {
+      this.listenTo(this.collection, 'all', this._onCollectionEvent);
+    },
+
+    _unbind: function (){
+      this.stopListening(this.collection, 'all', this._onCollectionEvent);
     }
-    if (this.collection === collection) return;
-    this._unbind();
-    this.collection = collection;
-    this._bindToCollection();
-    this._syncWithCollection();
-    this.trigger('reset', this, { switched: true });
-  },
+}, Events);
 
-  _onCollectionEvent: function() {
-    this._syncWithCollection();
-    this.trigger.apply(this, arguments);
-  },
-
-  _syncWithCollection: function() {
-    this.length = this.collection.length;
-    this.models = this.collection.models;
-    this.model  = this.collection.model;
-  },
-
-  _bindToCollection: function() {
-    var collection = this.collection;
-    var self = this;
-
-    for(var key in collection){
-      if(/^_/.test(key)) continue;
-      if(protectedMethods.indexOf(key) != -1) continue;
-      if(_.isFunction(collection[key])) this[key] = collection[key].bind(collection);
-    }
-
-    //avoid multipl bindings
-    this.stopListening(collection, 'all', this._onCollectionEvent, this);
-
-    //listen to every event
-    this.listenTo(collection, 'all', this._onCollectionEvent, this);
-  },
-
-  _unbind: function (){
-    this.stopListening(this.collection, 'all', this._onCollectionEvent, this);
-  },
+Object.keys(BackboneCollectionPrototype).forEach(function(key) {
+  var entry = BackboneCollectionPrototype[key];
+  if (allowMethod(key, entry)) {
+    ProxyCollection.prototype[key] = function() {
+      return this.collection[key].apply(this.collection, arguments);
+    };
+  }
 });
+
+function allowMethod(key, entry) {
+  if (key[0] === '_') return;
+  if (typeof entry !== 'function') return;
+  if (Events.hasOwnProperty(key)) return;
+  if (ProxyCollection.prototype.hasOwnProperty(key)) return;
+  if (key === 'constructor' || key === 'initialize' || key === 'comparator') return;
+
+  return true;
+}
 
 module.exports = ProxyCollection;

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -21,9 +21,7 @@
   mocha.checkLeaks();
   mocha.globals(['console', '_console_log', 'BrowserStack']);
   window.onload = function(){
-    console.log('STARTED');
     mocha.run(function(){
-        console.log('FINISHED');
         mocha.bail();
     });
   }

--- a/test/specs/custom-collection.js
+++ b/test/specs/custom-collection.js
@@ -24,6 +24,7 @@ beforeEach(function() {
 
   proxyCollection = new ProxyCollection({
     collection: collection,
+    klass: CustomCollection
   });
 });
 

--- a/test/specs/methods.js
+++ b/test/specs/methods.js
@@ -15,6 +15,7 @@ describe('ProxyCollection methods compared to Backbone.Collection', function() {
       if (/^_/.test(key)) continue;
       if (key === 'modelId') continue;
       if (key === 'collect') continue;
+      if (key === 'initialize') continue;
 
       assert.equal(typeof proxyCollection[key], typeof collection[key], 'Proxy collection should contain a property of ' + key);
     }

--- a/test/specs/properties.js
+++ b/test/specs/properties.js
@@ -1,0 +1,39 @@
+var assert          = require('assert');
+var ProxyCollection = require('../../index');
+var Backbone        = require('backbone');
+
+var proxyCollection;
+var collection;
+var secondaryCollection;
+
+beforeEach(function() {
+  collection = new Backbone.Collection([
+  ]);
+  collection.customProperty = 'one';
+
+  secondaryCollection = new Backbone.Collection([
+  ]);
+  secondaryCollection.customProperty = 'two';
+
+
+  proxyCollection = new ProxyCollection({
+    collection: collection,
+    properties: ['customProperty']
+  });
+});
+
+describe('ProxyCollection.properties', function() {
+
+  it('Should handle properties', function() {
+    var result = proxyCollection.customProperty;
+    assert.equal('one', result);
+  });
+
+  it('Should handle properties after switch', function() {
+    proxyCollection.switchCollection(secondaryCollection);
+
+    var result = proxyCollection.customProperty;
+    assert.equal('two', result);
+  });
+
+});


### PR DESCRIPTION
There are cases where it would be useful to be able to proxy custom properties from the backend collections.

For example, we use a mixin which tracks the loading state of a collection. For example, during a `fetch` the collection is loading and once the `sync` is completed the state changed to `.loading = false`.

This PR allows these methods to be proxied through the collection.

A side-effect is that we don't need to reapply `.length` etc on every event.

A second side effect of the PR is that the method stubs are not regenerated on every room switch.
